### PR TITLE
Updated Manifest files to ensure support for Visual Studio 2012 - 2019.

### DIFF
--- a/CodeMetrics.Adornments/source.extension.vsixmanifest
+++ b/CodeMetrics.Adornments/source.extension.vsixmanifest
@@ -6,10 +6,10 @@
         <Description>Code complexity addin</Description>
     </Metadata>
     <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0,17.0)" />
-        <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[14.0,17.0)" />
-        <InstallationTarget Id="Microsoft.VisualStudio.Premium" Version="[14.0,17.0)" />
-        <InstallationTarget Id="Microsoft.VisualStudio.Ultimate" Version="[14.0,17.0)" />
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[11.0,17.0)" />
+        <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[11.0,17.0)" />
+        <InstallationTarget Id="Microsoft.VisualStudio.Premium" Version="[11.0,17.0)" />
+        <InstallationTarget Id="Microsoft.VisualStudio.Ultimate" Version="[11.0,17.0)" />
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.0,)" />


### PR DESCRIPTION
Updated Manifest files to ensure support for Visual Studio 2012 - 2019.

Previous commit would have resulted in only Visual Studio 2015 - 2019 being supported for this Extension.

This commit aims to prevent the above potential regression.